### PR TITLE
Give player more space on the top

### DIFF
--- a/src/styles/pages/home/_spotify-player.scss
+++ b/src/styles/pages/home/_spotify-player.scss
@@ -1,6 +1,9 @@
 @import '../../base/colors';
+@import '../../base/breakpoints';
 
 .SpotifyPlayer {
+  padding-top: 1rem;
+
   p {
     margin: 0;
   }


### PR DESCRIPTION
Add `padding-top` to the content section below the home page image